### PR TITLE
fix: rollback

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -42,13 +42,8 @@ jobs:
             echo "[EC2] Stopping previous server..."
             PID=$(pgrep -f 'java -Dspring.profiles.active=dev -jar app.jar')
             if [ -n "$PID" ]; then
-            echo "Stopping PID: $PID"
-            kill -15 "$PID"            # graceful SIGTERM
-            for i in {1..15}; do       # wait up to 15 s
-              if ! kill -0 "$PID" 2>/dev/null; then break; fi
-              sleep 1
-            done
-            kill -9 "$PID" 2>/dev/null || true  # hard kill if still alive
+            echo "Killing PID: $PID"
+            (sleep 1 && kill $PID) &
             else
             echo "No running app.jar process found."
             fi


### PR DESCRIPTION
## 📌 PR 요약
- rollback

## 🔗 관련 이슈
- 관련된 이슈 번호를 연결해주세요.
    - closed #9 

## 🛠️ 변경 사항
- Stop Previous Application on EC2 부분에서 배포시 오류로 인해 롤백

## 📸 스크린샷 (선택)
UI 변경 사항이 있다면 스크린샷을 첨부해주세요.

| 기능 | 스크린샷 |
| --- | --- |
| PNG | ![스크린샷](사진을 넣어주세요) |

## ⚠️ 주의 사항 (선택)
리뷰어가 알아야 할 중요한 사항이나 주의할 점을 작성해주세요.

## ✅ 체크리스트
PR 작성자가 확인해야 할 항목입니다:
- [x] 코드가 정상적으로 동작하는지 확인했습니다.
- [ ] 관련 문서를 업데이트했습니다.
- [ ] 코드 리뷰어를 등록했습니다.
- [x] Labels를 등록했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated deployment process to simplify how the previous application instance is stopped during deployment. The log message now indicates "Killing PID" instead of "Stopping PID".
<!-- end of auto-generated comment: release notes by coderabbit.ai -->